### PR TITLE
Img tag for CSS downlod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+
+#NOTE
+
+A better plugin with all the cases handled, good support for r.js and less is available at https://github.com/guybedford/require-css. You should better have look at that if you are looking at this.
+
+----------------------------------------------------------------------------------------------------------------
+
 # RequireCSS (RequireJS _css!_ plugin)
 
 A [RequireJS][1] plugin which loads and waits for css files. Uses the standard load event on browsers which support it (IE, Firefox 9+, Opera) and uses a script tags load & error events as a workaround (Chrome, Safari, Firefox < 9). Detection of link load event support is done using a link element with a data url, which fires onload immediately when supported.

--- a/css.js
+++ b/css.js
@@ -61,7 +61,7 @@
 	 */
 	function loadScript(url, load) {
 		var link = createLink(url),
-			script = doc.createElement('script');
+			script = doc.createElement('img');
 
 		head.appendChild(link);
 


### PR DESCRIPTION
Using img tag solves problem of errors getting shown in error console for each CSS downlod.
